### PR TITLE
chore(NOJIRA-1): Fix CI GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - main
 
-env:
-
 jobs:
   build:
     strategy:


### PR DESCRIPTION
The `ci.yml` fails to run because it's an invalid GitHub workflow. The error that GitHub reports is:
```
The workflow is not valid. .github/workflows/ci.yml (Line: 11, Col: 5): Unexpected value ''
```

It's probably caused by having an empty `env` object, so this PR removes it.