### PR TITLE
chore(NOJIRA-1): Fix Deploy GHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,3 +48,5 @@ jobs:
         run: |
           npm run build
           npm run semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
The `Deploy` step from the `deploy.yml` GitHub Action is failing because it's missing the `GH_TOKEN` env var. This PR adds it.